### PR TITLE
Add hex-rgb dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "babili": "0.0.9",
     "cerebro-tools": "^0.1.0",
     "css-loader": "^0.26.0",
+    "hex-rgb": "^1.0.0",
     "react": "^15.4.1",
     "style-loader": "^0.13.1",
     "url-loader": "^0.5.7",


### PR DESCRIPTION
fixes build error

```
➜  cerebro-convertcolor npm i

> fsevents@1.1.1 install /foo/documents/cerebro-convertcolor/node_modules/fsevents
> node install

[fsevents] Success: "/foo/documents/cerebro-convertcolor/node_modules/fsevents/lib/binding/Release/node-v48-darwin-x64/fse.node" already installed
Pass --update-binary to reinstall or --build-from-source to recompile

> convert-color@0.0.2 prepublish /foo/documents/cerebro-convertcolor
> rm -rf ./dist && npm run build


> convert-color@0.0.2 build /foo/documents/cerebro-convertcolor
> webpack && babili dist -d dist --compact --no-comments

keywords if/then/else require v5 option
Hash: 1ed6e7a9ca9fb63e3bc1
Version: webpack 2.1.0-beta.27
Time: 517ms
   Asset     Size  Chunks             Chunk Names
index.js  6.36 kB       0  [emitted]  index
    + 2 hidden modules

ERROR in ./src/index.js
Module not found: Error: Can't resolve 'hex-rgb' in '/foo/documents/cerebro-convertcolor/src'
 @ ./src/index.js 3:14-32

npm ERR! Darwin 16.4.0
npm ERR! argv "/foo/.nvm/versions/node/v6.9.5/bin/node" "/foo/.nvm/versions/node/v6.9.5/bin/npm" "run" "build"
npm ERR! node v6.9.5
npm ERR! npm  v3.10.10
npm ERR! code ELIFECYCLE
npm ERR! convert-color@0.0.2 build: `webpack && babili dist -d dist --compact --no-comments`
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the convert-color@0.0.2 build script 'webpack && babili dist -d dist --compact --no-comments'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the convert-color package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     webpack && babili dist -d dist --compact --no-comments
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs convert-color
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls convert-color
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /foo/documents/cerebro-convertcolor/npm-debug.log

npm WARN url-loader@0.5.7 requires a peer of file-loader@* but none was installed.
npm ERR! Darwin 16.4.0
npm ERR! argv "/foo/.nvm/versions/node/v6.9.5/bin/node" "/foo/.nvm/versions/node/v6.9.5/bin/npm" "i"
npm ERR! node v6.9.5
npm ERR! npm  v3.10.10
npm ERR! code ELIFECYCLE
npm ERR! convert-color@0.0.2 prepublish: `rm -rf ./dist && npm run build`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the convert-color@0.0.2 prepublish script 'rm -rf ./dist && npm run build'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the convert-color package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     rm -rf ./dist && npm run build
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs convert-color
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls convert-color
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /foo/documents/cerebro-convertcolor/npm-debug.log
```