### PR TITLE
Add copy to clipboard feature

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,6 @@ const plugin = ({term, display, actions}) => {
       id,
       icon,
       title: `Your color: ${color == undefined ? '...' : color}`,
-      clipboard: 'My title',
       getPreview: () => {
         'teste'
       }

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,9 @@ const plugin = ({term, display, actions}) => {
       title: `Your color: ${color == undefined ? '...' : color}`,
       getPreview: () => {
         'teste'
+      },
+      onSelect: () => {
+        actions.copyToClipboard(color);
       }
     });
   }


### PR DESCRIPTION
use clipboard function provided by context

context is a object passed to plugin fn
here is plugin fn: https://github.com/rafa-acioly/cerebro-convertcolor/blob/df85b2da5d2683dc26ee34e9a041b17ba0b77676/src/index.js#L53
and context destructuring https://github.com/rafa-acioly/cerebro-convertcolor/blob/df85b2da5d2683dc26ee34e9a041b17ba0b77676/src/index.js#L30

arguments passed to fn: https://github.com/KELiON/cerebro/blob/adba0769998a9769454d80e75ebeb1119a9ebb77/app/main/actions/search.js#L42 , including default scope: https://github.com/KELiON/cerebro/blob/adba0769998a9769454d80e75ebeb1119a9ebb77/app/main/actions/search.js#L22

in docs: https://github.com/KELiON/cerebro/blob/029e62df76317d761bb9ab5eafe2983be2e21f2a/docs/plugins/plugin-structure.md